### PR TITLE
fix(nvim): install yaml-language-server and pin yaml devicon

### DIFF
--- a/.config/nvim/lua/settings/plugins-setup.lua
+++ b/.config/nvim/lua/settings/plugins-setup.lua
@@ -2,6 +2,15 @@
 vim.notify = require "notify"
 require("mason").setup()
 
+-- nvim-web-devicons remapped the yaml/yml icon to U+E8EB (red) in a recent
+-- update; restore the familiar Seti yaml glyph (U+E615, grey-blue) instead.
+require("nvim-web-devicons").setup {
+  override_by_extension = {
+    yaml = { icon = "", color = "#6D8086", cterm_color = "66", name = "Yaml" },
+    yml = { icon = "", color = "#6D8086", cterm_color = "66", name = "Yml" },
+  },
+}
+
 -- Load LuaSnip configuration early (before cmp)
 require "config.luasnip"
 

--- a/install/ansible-install.yml
+++ b/install/ansible-install.yml
@@ -428,6 +428,7 @@
         - typescript
         - typescript-language-server
         - bash-language-server
+        - yaml-language-server
         - markdownlint-cli
         - "@ast-grep/cli"
         - "@mermaid-js/mermaid-cli"


### PR DESCRIPTION
## What

- Add `yaml-language-server` to the ansible npm-globals list.
- Override the nvim-web-devicons yaml/yml icon back to the Seti glyph (U+E615, grey-blue).

## Why

`yamlls` failed to spawn on every YAML buffer because `yaml-language-server` was never installed (not in npm-global, not in Mason). It now installs on a fresh machine alongside `bash-language-server`.

A recent nvim-web-devicons update remapped the yaml/yml icon to a new glyph (U+E8EB, red) that the installed Nerd Font lacked, so buffer tabs rendered a tofu box. The override restores the familiar icon and keeps it stable across future devicons updates.

## Notes

The host font was also upgraded to JetBrainsMono Nerd Font v3.4.0 (outside the repo, in `~/.local/share/fonts/`) so newly remapped glyphs render. Not part of this diff.