### PR TITLE
feat: mirror linear slack threads onto tasks as taskopen slugs

### DIFF
--- a/.taskopenrc
+++ b/.taskopenrc
@@ -27,8 +27,39 @@ notes.regex="^Notes(\\..*)?"
 notes.command="""editnote ~/Notes/tasknotes/$UUID$LAST_MATCH "$TASK_DESCRIPTION" $UUID"""
 notes.modes="batch,any,normal"
 
+# PROJECT: slack-thread-annotations
+# See: scripts/__github_issue_sync.sh, scripts/__slack_open.sh
+# Slack threads and reference links mirrored from Linear attachments, written as
+# "slack: <url>" and "link: <url>". The space after the colon is deliberate: it
+# is what makes taskopen parse the word as a LABEL (its annotation grammar is
+# `(?:(\S+):\s+)?(.*)`), which is what labelregex below can then select on. The
+# older space-less "PR:<url>" form has no label, so it can only be matched as
+# raw text.
+#
+# The catch-all `url` action below matches any annotation containing http, and
+# in normal/batch mode taskopen runs only the FIRST matching action. Its
+# labelregex therefore excludes these two labels; without that exclusion `url`
+# wins and every Slack link opens in a browser. Placement in this file does NOT
+# fix it: despite what taskopenrc(5) says about config order setting priority,
+# taskopen 2.0.2 was measured resolving `url` first even with these actions
+# written above it.
+slack.target=annotations
+slack.labelregex="^slack$"
+slack.regex="(https?://[^\\s]+)"
+slack.command="__slack_open.sh $LAST_MATCH"
+slack.modes="batch,any,normal"
+
+link.target=annotations
+link.labelregex="^link$"
+link.regex="(https?://[^\\s]+)"
+link.command="open $LAST_MATCH 2>/dev/null"
+link.modes="batch,any,normal"
+
 url.target=annotations
-url.labelregex=".*"
+# Everything EXCEPT the two labels that have their own opener above. Other
+# labelled annotations ("upstream: https://...") keep falling through to here,
+# which is what they did before and still should.
+url.labelregex="^(?!slack$|link$).*"
 url.regex="((?:www|http).*)"
 url.command="open $LAST_MATCH 2>/dev/null"
 url.modes="batch,any,normal"
@@ -65,3 +96,14 @@ pr.labelregex=".*"
 pr.regex="^PR:(.*)"
 pr.command="open $LAST_MATCH 2>/dev/null"
 pr.modes="batch,any,normal"
+
+[CLI]
+# Scoping knobs, so a task carrying a brief, a Linear url, a PR, two Slack
+# threads and a Notion page does not force a hunt through a numbered list.
+# --include both restricts the actions considered AND sets their priority, so
+# these bypass the catch-all `url` action without reordering anything above.
+#   taskopen slack <filter>   jump straight to the Slack threads
+#   taskopen refs  <filter>   every external reference, nothing local
+alias.slack="normal --include=slack"
+alias.refs="any --include=slack,link,pr"
+group.refs="slack,link,pr"

--- a/scripts/__github_issue_sync.sh
+++ b/scripts/__github_issue_sync.sh
@@ -40,6 +40,14 @@ declare -A TEAM_PREFIX_REPO=(
     ["DOC"]="vcluster-docs"
 )
 
+# How many attachment links of ONE kind may be mirrored onto a single task.
+# The cap exists for the reading end, not the writing end: taskopen presents a
+# numbered list of actionable annotations, and Piotr has to pick from it. Linear
+# routinely carries far more than that (DOC-1675 alone holds 14 attachments, 13
+# of them PRs), so an uncapped mirror turns every pick into a hunt. Overflow is
+# always logged by attach_link_annotations, never silently dropped.
+LINK_ANNOTATION_CAP="${LINK_ANNOTATION_CAP:-3}"
+
 # ====================================================
 # LOGGING FUNCTIONS
 # ====================================================
@@ -150,7 +158,7 @@ get_linear_issues() {
             -X POST \
             -H "Content-Type: application/json" \
             -H "Authorization: ${LINEAR_API_KEY}" \
-            --data '{"query": "query { user(id: \"'"$LINEAR_USER_ID"'\") { id name assignedIssues(filter: { state: { name: { nin: [\"Released\", \"Canceled\",\"Done\",\"Ready for Release\",\"Duplicate\",\"Archived\"] } } }) { nodes { id title url state { name } project { name } dueDate priority updatedAt cycle { number } attachments { nodes { url } } } pageInfo { hasNextPage } } } }"}' \
+            --data '{"query": "query { user(id: \"'"$LINEAR_USER_ID"'\") { id name assignedIssues(filter: { state: { name: { nin: [\"Released\", \"Canceled\",\"Done\",\"Ready for Release\",\"Duplicate\",\"Archived\"] } } }) { nodes { id title url state { name } project { name } dueDate priority updatedAt cycle { number } attachments { nodes { url sourceType } } } pageInfo { hasNextPage } } } }"}' \
             https://api.linear.app/graphql 2>"$curl_stderr")
         exit_code=$?
 
@@ -220,7 +228,13 @@ get_linear_issues() {
             priority: .priority,
             updated_at: .updatedAt,
             cycle_number: .cycle.number,
-            pr_url: ([.attachments.nodes[]? | select(.url != null and (.url | test("github.com.*/pull/"))) | .url] | .[0] // null)
+            pr_url: ([.attachments.nodes[]? | select(.url != null and (.url | test("github.com.*/pull/"))) | .url] | .[0] // null),
+            slack_urls: ([.attachments.nodes[]? | select(.url != null and (.url | test("//[^/]*slack\\.com/archives/"))) | .url] | unique),
+            link_urls: ([.attachments.nodes[]?
+                         | select(.url != null and (.url | test("^https?://")))
+                         | select((.sourceType // "") | test("^(slack|github)$") | not)
+                         | select(.url | test("^https?://uploads\\.linear\\.app/") | not)
+                         | .url] | unique)
         }' 2>/dev/null); then
         echo "Error: Failed to parse Linear issues" >&2
         rm -f "$temp_response"
@@ -789,6 +803,90 @@ attach_pr_link() {
     annotate_task "$task_uuid" "$pr_url"
 }
 
+# Reduce a url to the part that identifies it across re-fetches: everything
+# before the query string and the fragment. Linear hands the SAME Slack thread
+# back with its query parameters in either order (both ?cid=..&thread_ts=.. and
+# ?thread_ts=..&cid=.. are live on the board right now), so an exact-string
+# comparison would read a parameter reshuffle as a brand-new link and annotate
+# the same thread again on some later sync. The path alone
+# (/archives/<CHANNEL>/p<TIMESTAMP>) already pins a Slack message uniquely, and
+# the same rule is correct for the other link kinds.
+link_identity() {
+    local url="$1"
+    url="${url%%#*}"
+    url="${url%%\?*}"
+    echo "$url"
+}
+
+# Mirror Linear attachment links onto a task as taskopen-labelled annotations.
+#
+# Written as "<label>: <url>" WITH the space, because that space is what makes
+# taskopen see a label at all: its annotation grammar is `(?:(\S+):\s+)?(.*)`,
+# so the older space-less "PR:https://..." form parses as one anonymous blob and
+# every action has to re-match the raw text. With a real label, .taskopenrc can
+# select on labelregex and `taskopen slack` can alias straight to one action
+# instead of printing every annotation on the task as a numbered choice.
+#
+# Add-only and idempotent. A link already present under ANY prefix is skipped,
+# matched on link_identity rather than the literal string, so re-running the
+# 30-minute sync never grows the list.
+attach_link_annotations() {
+    local task_uuid="$1"
+    local label="$2"
+    local urls="$3"
+
+    [[ -z "$task_uuid" || "$task_uuid" == "null" ]] && return 0
+    [[ -z "$urls" ]] && return 0
+
+    local task_json
+    task_json=$(task "$task_uuid" export 2>/dev/null)
+    [[ -z "$task_json" ]] && return 0
+
+    # Every url already annotated on this task, whatever prefix or prose wraps
+    # it, reduced to its identity. scan (not the whole annotation) because these
+    # links share the annotation channel with agent-written sentences.
+    local existing_ids=""
+    local seen_url
+    while IFS= read -r seen_url; do
+        [[ -z "$seen_url" ]] && continue
+        existing_ids+="$(link_identity "$seen_url")"$'\n'
+    done < <(echo "$task_json" \
+        | jq -r '[.[0].annotations[]? | (.description // "") | scan("https?://[^[:space:]]+")] | unique | .[]')
+
+    local attached=0
+    local skipped=0
+    local url identity
+    while IFS= read -r url; do
+        [[ -z "$url" || "$url" == "null" ]] && continue
+        identity=$(link_identity "$url")
+
+        # Already on the task (this run or an earlier one): never re-annotate.
+        if grep -Fxq -- "$identity" <<<"$existing_ids"; then
+            continue
+        fi
+
+        # Cap counts only links we would actually ADD, so a task that already
+        # carries three Slack threads does not report a phantom overflow.
+        if (( attached >= LINK_ANNOTATION_CAP )); then
+            skipped=$((skipped + 1))
+            continue
+        fi
+
+        log "Attaching $label link annotation: $url"
+        annotate_task "$task_uuid" "$label: $url"
+        existing_ids+="$identity"$'\n'
+        attached=$((attached + 1))
+    done <<<"$urls"
+
+    # Never truncate silently: a capped run must say what it left behind and how
+    # to see the rest, or the short list reads as "that was everything".
+    if (( skipped > 0 )); then
+        log "WARNING: $skipped further $label link(s) not annotated (cap LINK_ANNOTATION_CAP=$LINK_ANNOTATION_CAP); open the Linear issue for the full set, or raise the cap to mirror more"
+    fi
+
+    return 0
+}
+
 # Mark an open Linear issue whose PRs all died as a close candidate, with +kill.
 #
 # Linear never closes an issue when its PR is closed, and it never drops the
@@ -856,6 +954,8 @@ create_and_annotate_task() {
     local cycle_number="$9"
     local issue_updated_at="${10}"
     local issue_pr_url="${11}"
+    local issue_slack_urls="${12}"
+    local issue_link_urls="${13}"
 
     log "Creating new task for issue: $issue_description"
     
@@ -875,6 +975,8 @@ create_and_annotate_task() {
     if [[ -n "$task_uuid" ]]; then
         annotate_task "$task_uuid" "$issue_url"
         attach_pr_link "$task_uuid" "$issue_pr_url" "$issue_status"
+        attach_link_annotations "$task_uuid" "slack" "$issue_slack_urls"
+        attach_link_annotations "$task_uuid" "link" "$issue_link_urls"
         log "Task created and annotated for: $issue_description"
         task rc.confirmation=no modify "$task_uuid" linear_issue_id:"$issue_number"
         
@@ -921,7 +1023,7 @@ create_and_annotate_task() {
 # Synchronize a single issue with Taskwarrior
 sync_to_taskwarrior() {
     local issue_line="$1"
-    local issue_id issue_description issue_repo_name issue_url task_uuid issue_number project_name issue_status issue_due_date issue_priority cycle_number issue_updated_at pr_url
+    local issue_id issue_description issue_repo_name issue_url task_uuid issue_number project_name issue_status issue_due_date issue_priority cycle_number issue_updated_at pr_url slack_urls link_urls
 
     issue_id=$(echo "$issue_line" | jq -r '.id')
     issue_description=$(echo "$issue_line" | jq -r '.description')
@@ -944,6 +1046,11 @@ sync_to_taskwarrior() {
     issue_updated_at=$(echo "$issue_line" | jq -r '.updated_at // empty' | sed -E 's/\.[0-9]+Z$/Z/')
     # First github.com/.../pull/ URL among the Linear issue's attachments, if any.
     pr_url=$(echo "$issue_line" | jq -r '.pr_url // empty')
+    # Slack thread permalinks and other reference links, newline separated.
+    # Newline rather than space because IFS is $'\n\t' in this file, so a
+    # space-joined list would arrive at the callee as one unsplittable token.
+    slack_urls=$(echo "$issue_line" | jq -r '(.slack_urls // []) | .[]')
+    link_urls=$(echo "$issue_line" | jq -r '(.link_urls // []) | .[]')
 
     log "Processing Issue ID: $issue_id, Description: $issue_description"
 
@@ -974,7 +1081,7 @@ sync_to_taskwarrior() {
 
     if [[ -z "$task_uuid" || "$task_uuid" == "null" ]]; then
         log "No valid existing task found - creating new task"
-        create_and_annotate_task "$issue_description" "$issue_repo_name" "$issue_url" "$issue_number" "$project_name" "$issue_status" "$issue_due_date" "$issue_priority" "$cycle_number" "$issue_updated_at" "$pr_url"
+        create_and_annotate_task "$issue_description" "$issue_repo_name" "$issue_url" "$issue_number" "$project_name" "$issue_status" "$issue_due_date" "$issue_priority" "$cycle_number" "$issue_updated_at" "$pr_url" "$slack_urls" "$link_urls"
     else
         # Fix any issues with newlines in task_uuid
         task_uuid=$(echo "$task_uuid" | tr -d '\n')
@@ -1023,6 +1130,11 @@ sync_to_taskwarrior() {
 
         # Backfill the Linear-attached PR onto already-synced tasks (idempotent).
         attach_pr_link "$task_uuid" "$pr_url" "$issue_status"
+
+        # Same backfill for Slack threads and other reference links. Tasks that
+        # predate this feature pick their links up on the next sync.
+        attach_link_annotations "$task_uuid" "slack" "$slack_urls"
+        attach_link_annotations "$task_uuid" "link" "$link_urls"
 
         # Runs AFTER attach_pr_link so a PR annotation mirrored on this very run
         # is already visible to the verdict, instead of waiting 30 minutes.

--- a/scripts/__slack_open.sh
+++ b/scripts/__slack_open.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# PROJECT: slack-thread-annotations
+# See: __github_issue_sync.sh (writes the "slack: <url>" annotations), .taskopenrc
+#
+# Opens a Slack message permalink in the Slack desktop app instead of a browser
+# tab. Called by the `slack` action in .taskopenrc, which hands it the url part
+# of a "slack: <url>" annotation.
+#
+# Slack's own documentation (docs.slack.dev/interactivity/deep-linking) covers
+# exactly one channel form, `slack://channel?team=<TEAM_ID>&id=<CHANNEL_ID>`,
+# with team required, and documents NO parameter for addressing a single
+# message. The `message` and `thread_ts` parameters added below are undocumented
+# but are what the desktop client honours; if a Slack release ever stops
+# honouring them the link still resolves to the right channel, which is why they
+# are worth using and why nothing here depends on them.
+#
+# The team id is the one value a permalink cannot supply: it carries the
+# workspace DOMAIN (loft-labs-inc) and Slack's scheme wants the id (T0243...).
+# Rather than guess it, resolve it explicitly and fall back to the browser with
+# a remedy when it is unknown.
+
+set -eo pipefail
+
+TEAMS_CONFIG="${SLACK_OPEN_TEAMS_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/slack-open/teams}"
+SLACK_STATE_DIR="${SLACK_STATE_DIR:-$HOME/.var/app/com.slack.Slack/config/Slack}"
+OPENER="${SLACK_OPEN_OPENER:-xdg-open}"
+
+usage() {
+    cat <<'EOF'
+Usage: __slack_open.sh <slack-permalink>
+       __slack_open.sh --detect
+
+Opens a Slack message permalink in the Slack desktop app.
+
+  <slack-permalink>  https://<workspace>.slack.com/archives/<CHANNEL>/p<TS>[?thread_ts=..]
+  --detect           List team ids found in the local Slack app state, to fill
+                     in the workspace -> team id map.
+
+Team id resolution order:
+  1. $SLACK_TEAM_ID
+  2. <workspace> <TEAM_ID> line in the teams config
+  3. none found: opens the original https link in the browser instead
+
+Teams config: $XDG_CONFIG_HOME/slack-open/teams (default ~/.config/slack-open/teams)
+  # one "workspace teamid" pair per line, # comments allowed
+  loft-labs-inc T0123456789
+EOF
+}
+
+# Team ids the installed Slack app has on disk, most frequently referenced
+# first. Slack stores no clean domain -> id mapping we can read, so this is a
+# discovery aid for a human filling in the config once, never an auto-answer:
+# picking the most common id for the user would be a guess wearing a fact's
+# clothes.
+detect_team_ids() {
+    if [[ ! -d "$SLACK_STATE_DIR" ]]; then
+        echo "No local Slack app state at $SLACK_STATE_DIR" >&2
+        return 1
+    fi
+
+    echo "Team ids referenced in $SLACK_STATE_DIR (most referenced first):"
+    # \b and the digit filter matter: a bare T[0-9A-Z]{8,12} also matches the
+    # tail of ordinary upper-case words in the app bundle (NOTIFICATIONS,
+    # INTEGRATIONS, TABCOMPLETE), which buries the real id in noise. Every Slack
+    # team id contains at least one digit.
+    { grep -rhoaE '\bT[A-Z0-9]{7,11}\b' "$SLACK_STATE_DIR" 2>/dev/null || true; } \
+        | grep -E '[0-9]' \
+        | sort | uniq -c | sort -rn | head -5 \
+        | while read -r count team_id; do
+            printf '  %-14s (%s references)\n' "$team_id" "$count"
+        done
+
+    echo
+    echo "Take the workspace from your own permalink: the <workspace> in"
+    echo "https://<workspace>.slack.com/archives/... . Then record the pair in"
+    echo "$TEAMS_CONFIG, e.g.:"
+    echo "  loft-labs-inc T0123456789"
+}
+
+# Look a workspace domain up in the teams config. Silent on a miss; the caller
+# decides what a miss means.
+team_id_for_workspace() {
+    local workspace="$1"
+    local cfg_workspace cfg_team
+
+    [[ -r "$TEAMS_CONFIG" ]] || return 1
+
+    while read -r cfg_workspace cfg_team _; do
+        [[ -z "$cfg_workspace" || "$cfg_workspace" == \#* ]] && continue
+        if [[ "$cfg_workspace" == "$workspace" ]]; then
+            echo "$cfg_team"
+            return 0
+        fi
+    done < "$TEAMS_CONFIG"
+
+    return 1
+}
+
+# Slack permalinks encode the message timestamp as p<seconds><microseconds>
+# with the dot removed: p1785876243182299 is 1785876243.182299. The last six
+# digits are always the microseconds, so split from the right.
+permalink_ts_to_message_ts() {
+    local raw="$1"
+    [[ "$raw" =~ ^[0-9]{7,}$ ]] || return 1
+    echo "${raw:0:${#raw}-6}.${raw: -6}"
+}
+
+main() {
+    local url="${1:-}"
+
+    case "$url" in
+        -h|--help) usage; exit 0 ;;
+        "")        usage >&2; exit 1 ;;
+        --detect)  if detect_team_ids; then exit 0; else exit 1; fi ;;
+    esac
+
+    # Parse https://<workspace>.slack.com/archives/<CHANNEL>/p<DIGITS>[?query]
+    local workspace channel raw_ts query
+    if [[ ! "$url" =~ ^https?://([A-Za-z0-9._-]+)\.slack\.com/archives/([A-Za-z0-9]+)/p([0-9]+)(\?(.*))?$ ]]; then
+        # Not a message permalink (a channel link, a Slack file, a canvas).
+        # Nothing to convert, so hand it to the browser rather than fail: the
+        # user asked to open a link, not to be told about a regex.
+        echo "Not a Slack message permalink, opening in browser: $url" >&2
+        exec "$OPENER" "$url"
+    fi
+    workspace="${BASH_REMATCH[1]}"
+    channel="${BASH_REMATCH[2]}"
+    raw_ts="${BASH_REMATCH[3]}"
+    query="${BASH_REMATCH[5]}"
+
+    local message_ts
+    if ! message_ts=$(permalink_ts_to_message_ts "$raw_ts"); then
+        echo "Unparseable message timestamp 'p$raw_ts', opening in browser: $url" >&2
+        exec "$OPENER" "$url"
+    fi
+
+    # A reply carries thread_ts; opening it addresses the thread rather than
+    # just the parent channel.
+    local thread_ts=""
+    if [[ "$query" =~ (^|&)thread_ts=([0-9.]+) ]]; then
+        thread_ts="${BASH_REMATCH[2]}"
+    fi
+
+    local team_id="${SLACK_TEAM_ID:-}"
+    if [[ -z "$team_id" ]]; then
+        team_id=$(team_id_for_workspace "$workspace" || true)
+    fi
+
+    if [[ -z "$team_id" ]]; then
+        echo "No team id for workspace '$workspace', opening in browser instead." >&2
+        echo "To open in the Slack app: run '$(basename "$0") --detect', then add a line" >&2
+        echo "'$workspace <TEAM_ID>' to $TEAMS_CONFIG (or set SLACK_TEAM_ID)." >&2
+        exec "$OPENER" "$url"
+    fi
+
+    local deep_link="slack://channel?team=${team_id}&id=${channel}&message=${message_ts}"
+    [[ -n "$thread_ts" ]] && deep_link+="&thread_ts=${thread_ts}"
+
+    exec "$OPENER" "$deep_link"
+}
+
+main "$@"

--- a/tests/bats/github_issue_sync_test.bats
+++ b/tests/bats/github_issue_sync_test.bats
@@ -2947,3 +2947,184 @@ _pr_annotations() {
     [ "$status" -eq 0 ]
     grep -q -- "+kill" "${TEST_DIR}/task_commands.log"
 }
+
+# ====================================================
+# SLACK THREAD / REFERENCE LINK ANNOTATION TESTS
+# ====================================================
+
+# A Linear response carrying the attachment shapes seen live on the board.
+_write_curl_mock_with_attachments() {
+    local attachments="$1"
+    cat > "${TEST_DIR}/curl" << EOF
+#!/bin/bash
+if [[ "\$*" =~ "linear.app" ]]; then
+    cat << 'RESPONSE'
+{
+  "data": { "user": { "assignedIssues": { "nodes": [
+    {
+      "id": "test-id",
+      "title": "Slack linked issue",
+      "url": "https://linear.app/loft/issue/DEVOPS-1293/slack",
+      "state": {"name": "Todo"},
+      "project": {"name": "operations"},
+      "dueDate": null,
+      "priority": 3,
+      "updatedAt": "2026-08-05T10:00:00.000Z",
+      "cycle": null,
+      "attachments": { "nodes": ${attachments} }
+    }
+  ]}}}
+}
+200
+RESPONSE
+else
+    /usr/bin/curl "\$@"
+fi
+EOF
+    chmod +x "${TEST_DIR}/curl"
+}
+
+@test "get_linear_issues requests sourceType so link kinds can be told apart" {
+    # Without sourceType every non-PR attachment looks alike and the reference
+    # bucket cannot exclude Linear's own file uploads.
+    cat > "${TEST_DIR}/curl" << 'EOF'
+#!/bin/bash
+echo "$*" >> "${TEST_DIR}/curl_args.log"
+if [[ "$*" =~ "linear.app" ]]; then
+    echo '{"data":{"user":{"assignedIssues":{"nodes":[]}}}}'
+    echo "200"
+else
+    /usr/bin/curl "$@"
+fi
+EOF
+    chmod +x "${TEST_DIR}/curl"
+
+    run get_linear_issues
+    [ "$status" -eq 0 ]
+    grep -q "sourceType" "${TEST_DIR}/curl_args.log"
+}
+
+@test "get_linear_issues extracts slack thread permalinks as slack_urls" {
+    _write_curl_mock_with_attachments '[
+        {"url": "https://github.com/loft-sh/loft-prod/pull/612", "sourceType": "github"},
+        {"url": "https://loft-labs-inc.slack.com/archives/C0735R36BJS/p1773732437844199?cid=C0735R36BJS&thread_ts=1773674424.979789", "sourceType": "slack"}
+    ]'
+
+    run get_linear_issues
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.slack_urls | length')" = "1" ]
+    [ "$(echo "$output" | jq -r '.slack_urls[0]')" = "https://loft-labs-inc.slack.com/archives/C0735R36BJS/p1773732437844199?cid=C0735R36BJS&thread_ts=1773674424.979789" ]
+    # A Slack thread is not a PR and must never leak into pr_url.
+    [ "$(echo "$output" | jq -r '.pr_url')" = "https://github.com/loft-sh/loft-prod/pull/612" ]
+}
+
+@test "get_linear_issues yields an empty slack_urls array when no thread is attached" {
+    _write_curl_mock_with_attachments '[
+        {"url": "https://github.com/loft-sh/loft-prod/pull/612", "sourceType": "github"}
+    ]'
+
+    run get_linear_issues
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.slack_urls | length')" = "0" ]
+}
+
+@test "get_linear_issues buckets other reference links but skips linear file uploads" {
+    # oauthClient uploads.linear.app entries are Linear's own file blobs: they
+    # are not references a human would ever want to open from the task.
+    _write_curl_mock_with_attachments '[
+        {"url": "https://github.com/loft-sh/loft-prod/pull/612", "sourceType": "github"},
+        {"url": "https://loft-labs-inc.slack.com/archives/C073/p1773732437844199", "sourceType": "slack"},
+        {"url": "https://app.notion.com/p/3b3109408069814f9d2cdebe5f8f2415", "sourceType": "api"},
+        {"url": "https://uploads.linear.app/0aab/541a/c696", "sourceType": "oauthClient"}
+    ]'
+
+    run get_linear_issues
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.link_urls | length')" = "1" ]
+    [ "$(echo "$output" | jq -r '.link_urls[0]')" = "https://app.notion.com/p/3b3109408069814f9d2cdebe5f8f2415" ]
+}
+
+@test "link_identity drops the query string and fragment" {
+    run link_identity "https://loft-labs-inc.slack.com/archives/C036/p1785876243182299?thread_ts=1785876243.182299&cid=C036"
+    [ "$status" -eq 0 ]
+    [ "$output" = "https://loft-labs-inc.slack.com/archives/C036/p1785876243182299" ]
+}
+
+@test "attach_link_annotations writes a taskopen label, colon AND space" {
+    # The space is what makes taskopen parse 'slack' as a label rather than as
+    # part of an anonymous blob, which is what .taskopenrc's labelregex selects.
+    _write_task_mock_export '["linear"]' '[]'
+
+    run attach_link_annotations "test-uuid" "slack" "https://loft-labs-inc.slack.com/archives/C036/p1785876243182299"
+    [ "$status" -eq 0 ]
+    grep -q "slack: https://loft-labs-inc.slack.com/archives/C036/p1785876243182299" "${TEST_DIR}/annotate.log"
+}
+
+@test "attach_link_annotations does not re-annotate a link already present" {
+    _write_task_mock_export '["linear"]' \
+        '[{"description":"slack: https://loft-labs-inc.slack.com/archives/C036/p1785876243182299"}]'
+
+    run attach_link_annotations "test-uuid" "slack" "https://loft-labs-inc.slack.com/archives/C036/p1785876243182299"
+    [ "$status" -eq 0 ]
+    [ ! -f "${TEST_DIR}/annotate.log" ]
+}
+
+@test "attach_link_annotations survives Linear reordering the query parameters" {
+    # Both parameter orders are live on the real board for the same thread. An
+    # exact-string check would read the reshuffle as a new link and duplicate it.
+    _write_task_mock_export '["linear"]' \
+        '[{"description":"slack: https://loft-labs-inc.slack.com/archives/C036/p1785876243182299?cid=C036&thread_ts=1785876243.182299"}]'
+
+    run attach_link_annotations "test-uuid" "slack" \
+        "https://loft-labs-inc.slack.com/archives/C036/p1785876243182299?thread_ts=1785876243.182299&cid=C036"
+    [ "$status" -eq 0 ]
+    [ ! -f "${TEST_DIR}/annotate.log" ]
+}
+
+@test "attach_link_annotations finds a link already annotated under another prefix" {
+    # Agents write URLs inside prose. Re-mirroring one as a fresh slug would put
+    # the same thread on the task twice.
+    _write_task_mock_export '["linear"]' \
+        '[{"description":"discussed here https://loft-labs-inc.slack.com/archives/C036/p1785876243182299 with the team"}]'
+
+    run attach_link_annotations "test-uuid" "slack" "https://loft-labs-inc.slack.com/archives/C036/p1785876243182299"
+    [ "$status" -eq 0 ]
+    [ ! -f "${TEST_DIR}/annotate.log" ]
+}
+
+@test "attach_link_annotations caps the number of links it mirrors" {
+    # The cap protects the taskopen picker, which is a numbered list a human
+    # reads.
+    _write_task_mock_export '["linear"]' '[]'
+    export LINK_ANNOTATION_CAP=2
+
+    run attach_link_annotations "test-uuid" "slack" "https://x.slack.com/archives/C1/p1000000000000001
+https://x.slack.com/archives/C2/p1000000000000002
+https://x.slack.com/archives/C3/p1000000000000003
+https://x.slack.com/archives/C4/p1000000000000004"
+    [ "$status" -eq 0 ]
+    [ "$(grep -c "MOCK: annotate" "${TEST_DIR}/annotate.log")" -eq 2 ]
+}
+
+@test "attach_link_annotations warns with a remedy about what the cap dropped" {
+    # A silently short list reads as 'that was everything'.
+    _write_task_mock_export '["linear"]' '[]'
+    export LINK_ANNOTATION_CAP=1
+
+    run attach_link_annotations "test-uuid" "slack" "https://x.slack.com/archives/C1/p1000000000000001
+https://x.slack.com/archives/C2/p1000000000000002
+https://x.slack.com/archives/C3/p1000000000000003"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "2 further slack link"
+    echo "$output" | grep -q "LINK_ANNOTATION_CAP"
+    # Names what to do about it, not just that it happened.
+    echo "$output" | grep -q "raise the cap"
+}
+
+@test "attach_link_annotations is a no-op on an empty url list" {
+    _write_task_mock_export '["linear"]' '[]'
+
+    run attach_link_annotations "test-uuid" "slack" ""
+    [ "$status" -eq 0 ]
+    [ ! -f "${TEST_DIR}/annotate.log" ]
+}

--- a/tests/bats/helpers/test_helper.bash
+++ b/tests/bats/helpers/test_helper.bash
@@ -2,10 +2,17 @@
 
 # Test helper functions for __github_issue_sync.sh tests
 
+# Repo root, derived from this helper's own location rather than hardcoded.
+# The path used to be /home/decoder/dev/dotfiles, which meant a suite run from a
+# git worktree silently sourced the MAIN checkout: the tests passed while never
+# executing a line of the code under change.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export REPO_ROOT
+
 # Load the main script without executing it
 load_github_sync_functions() {
     # Source just the functions, not the main execution
-    source <(sed '/^main$/,$d' /home/decoder/dev/dotfiles/scripts/__github_issue_sync.sh)
+    source <(sed '/^main$/,$d' "${REPO_ROOT}/scripts/__github_issue_sync.sh")
 }
 
 # Mock API responses using fixtures
@@ -15,7 +22,7 @@ mock_github_api() {
 #!/bin/bash
 case "\$*" in
     *"search/issues"*)
-        cat /home/decoder/dev/dotfiles/test/fixtures/${fixture_file}
+        cat ${REPO_ROOT}/test/fixtures/${fixture_file}
         ;;
     *)
         echo "Mock GitHub API: \$*" >&2
@@ -33,7 +40,7 @@ mock_linear_api() {
     cat > "${TEST_DIR}/curl" << EOF
 #!/bin/bash
 if [[ "\$*" =~ "linear.app" ]]; then
-    cat /home/decoder/dev/dotfiles/test/fixtures/${fixture_file}
+    cat ${REPO_ROOT}/test/fixtures/${fixture_file}
     echo "${http_code}"
 else
     /usr/bin/curl "\$@"

--- a/tests/bats/slack_open_test.bats
+++ b/tests/bats/slack_open_test.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+
+# Test suite for __slack_open.sh
+#
+# Every test stubs the opener, so nothing here can reach the real Slack app or a
+# browser: the script is exercised through SLACK_OPEN_OPENER, which exists for
+# exactly this reason.
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export TEST_DIR
+
+    REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+    export REPO_ROOT
+    SCRIPT="${REPO_ROOT}/scripts/__slack_open.sh"
+    export SCRIPT
+
+    cat > "${TEST_DIR}/opener" << 'EOF'
+#!/bin/bash
+echo "$*" > "${TEST_DIR}/opened"
+EOF
+    chmod +x "${TEST_DIR}/opener"
+    export SLACK_OPEN_OPENER="${TEST_DIR}/opener"
+
+    # Point the team map and the Slack state at empty test locations so a real
+    # ~/.config or a real Slack install can never change a result.
+    export SLACK_OPEN_TEAMS_CONFIG="${TEST_DIR}/teams"
+    export SLACK_STATE_DIR="${TEST_DIR}/slack-state"
+    unset SLACK_TEAM_ID
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+opened() {
+    cat "${TEST_DIR}/opened" 2>/dev/null
+}
+
+@test "converts a message permalink into a slack:// deep link" {
+    export SLACK_TEAM_ID="T024313FSQZ"
+
+    run "$SCRIPT" "https://loft-labs-inc.slack.com/archives/C0364G7S4UR/p1785876243182299"
+    [ "$status" -eq 0 ]
+    [ "$(opened)" = "slack://channel?team=T024313FSQZ&id=C0364G7S4UR&message=1785876243.182299" ]
+}
+
+@test "splits the permalink timestamp six digits from the right" {
+    # p1785876243182299 is 1785876243.182299; the last six digits are always
+    # the microseconds.
+    export SLACK_TEAM_ID="T1"
+
+    run "$SCRIPT" "https://ws.slack.com/archives/C1/p1773732437844199"
+    [ "$status" -eq 0 ]
+    echo "$(opened)" | grep -q "message=1773732437.844199"
+}
+
+@test "carries thread_ts through so a reply opens its thread" {
+    export SLACK_TEAM_ID="T1"
+
+    run "$SCRIPT" "https://ws.slack.com/archives/C1/p1785876243182299?thread_ts=1785876243.182299&cid=C1"
+    [ "$status" -eq 0 ]
+    echo "$(opened)" | grep -q "thread_ts=1785876243.182299"
+}
+
+@test "omits thread_ts when the permalink carries none" {
+    export SLACK_TEAM_ID="T1"
+
+    run "$SCRIPT" "https://ws.slack.com/archives/C1/p1785876243182299?cid=C1"
+    [ "$status" -eq 0 ]
+    ! echo "$(opened)" | grep -q "thread_ts"
+}
+
+@test "reads the team id from the teams config when the env var is unset" {
+    echo "# comment line" > "${TEST_DIR}/teams"
+    echo "other-workspace TOTHER" >> "${TEST_DIR}/teams"
+    echo "loft-labs-inc T024313FSQZ" >> "${TEST_DIR}/teams"
+
+    run "$SCRIPT" "https://loft-labs-inc.slack.com/archives/C1/p1785876243182299"
+    [ "$status" -eq 0 ]
+    echo "$(opened)" | grep -q "team=T024313FSQZ"
+}
+
+@test "SLACK_TEAM_ID wins over the teams config" {
+    echo "loft-labs-inc TFROMFILE" > "${TEST_DIR}/teams"
+    export SLACK_TEAM_ID="TFROMENV"
+
+    run "$SCRIPT" "https://loft-labs-inc.slack.com/archives/C1/p1785876243182299"
+    [ "$status" -eq 0 ]
+    echo "$(opened)" | grep -q "team=TFROMENV"
+}
+
+@test "falls back to the browser when no team id is known" {
+    # The team id is the one value a permalink cannot supply. Not knowing it
+    # must degrade to the original link, never to a broken deep link.
+    run "$SCRIPT" "https://unknown-ws.slack.com/archives/C1/p1785876243182299"
+    [ "$status" -eq 0 ]
+    [ "$(opened)" = "https://unknown-ws.slack.com/archives/C1/p1785876243182299" ]
+}
+
+@test "the fallback names the remedy, not just the problem" {
+    run "$SCRIPT" "https://unknown-ws.slack.com/archives/C1/p1785876243182299"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q -- "--detect"
+    echo "$output" | grep -q "unknown-ws <TEAM_ID>"
+}
+
+@test "hands a non-permalink slack url to the browser unchanged" {
+    export SLACK_TEAM_ID="T1"
+
+    run "$SCRIPT" "https://loft-labs-inc.slack.com/canvas/C1234"
+    [ "$status" -eq 0 ]
+    [ "$(opened)" = "https://loft-labs-inc.slack.com/canvas/C1234" ]
+}
+
+@test "exits non-zero with usage when given no argument" {
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q "Usage:"
+}


### PR DESCRIPTION
## What

The Slack thread that explains an issue was reachable only by opening the Linear issue in a browser and hunting for the attachment. Linear already holds it, and the sync never asked: `get_linear_issues` requested the attachments connection only for `github.com/*/pull/` urls.

Slack thread permalinks now land on the Taskwarrior task as `slack: <url>` annotations, other reference links (Notion, vendor docs) as `link: <url>`, and a new `slack` action in `.taskopenrc` opens them in the Slack desktop app instead of a browser tab.

Verified against the live Linear feed: 6 assigned issues carry threads that were previously invisible (DEVOPS-1293 with two, DEVOPS-1184, DEVOPS-1165, DEVOPS-1159, DEVOPS-943, ENGAI-42), plus the Notion and OpenAI links on DEVOPS-1293.

## Changes

- `scripts/__github_issue_sync.sh`: query asks for `sourceType`; new `slack_urls` and `link_urls` buckets; new `attach_link_annotations` and `link_identity`, called on both task creation and the existing-task backfill so already-synced tasks pick their links up on the next run.
- `scripts/__slack_open.sh` (new): converts a permalink to a `slack://` deep link, with `--detect` to help fill in the one-time team id config.
- `.taskopenrc`: `slack` and `link` actions, `url.labelregex` tightened, `[CLI]` aliases `taskopen slack` and `taskopen refs`.
- `tests/bats/helpers/test_helper.bash`: stop hardcoding `/home/decoder/dev/dotfiles`.

## Two findings worth not rediscovering

**taskopen 2.0.2 does not honour config order for action priority, despite taskopenrc(5) saying it does.** The man page states "taskopen is sensitive to the order in which the actions are specified. This order determines the priority". It is not. I first placed the new actions above the catch-all `url` action; a probe with stub openers showed `url` still resolved first, so every Slack link would have opened in a browser. `taskopen diagnostics` also lists actions in an order unrelated to the file. The fix is `url.labelregex="^(?!slack$|link$).*"`, which scopes the catch-all instead of relying on position. Negative lookahead does work in taskopen's regex engine.

Before tightening it I checked the live board: 157 annotations carry a taskopen label, including `upstream: https://github.com/...` which depends on the `url` action. Verified that `upstream: <url>`, bare urls and `PR:<url>` all still open exactly as before.

**Slack documents no deep-link parameter for addressing a single message, and a permalink cannot supply the team id.** [docs.slack.dev/interactivity/deep-linking](https://docs.slack.dev/interactivity/deep-linking/) documents exactly one channel form, `slack://channel?team=<TEAM_ID>&id=<CHANNEL_ID>`, with team required. The `message` and `thread_ts` parameters this uses are undocumented but are what the desktop client honours; if a Slack release drops them the link still resolves to the right channel. The permalink carries the workspace domain (`loft-labs-inc`), not the team id (`T024313FSQZ`), so the team id has to be configured. Nothing is hardcoded: resolution is `$SLACK_TEAM_ID`, then `~/.config/slack-open/teams`, then fall back to the browser naming the remedy.

## To make it live after merge

Stow, then add one line to `~/.config/slack-open/teams`:

```
loft-labs-inc T024313FSQZ
```

`__slack_open.sh --detect` reports that id with 22,708 references in the local Slack app state, but confirming it means opening Slack, so it is left to you. Without the line, Slack annotations still open, just in a browser.

## Design notes

Idempotency keys on the url with query and fragment stripped, not the literal string. Linear serves the same thread with its parameters in either order (`?cid=..&thread_ts=..` and `?thread_ts=..&cid=..` are both live on the board), so exact matching would re-annotate on a reshuffle. It also skips a link already annotated inside agent-written prose.

Capped at three links per kind (`LINK_ANNOTATION_CAP`): the taskopen picker is a numbered list a human reads, and DOC-1675 alone carries 14 attachments. Overflow logs a warning naming the remedy rather than truncating silently. Linear's own `uploads.linear.app` file blobs are excluded.

The space in `slack: <url>` is load-bearing. taskopen's annotation grammar is `(?:(\S+):\s+)?(.*)`, so the space is what makes it parse the word as a label, which is what `labelregex` selects on. The older space-less `PR:<url>` form has no label and can only be matched as raw text.

## Testing

- `bats tests/bats/github_issue_sync_test.bats`: 130/130 (15 new)
- `bats tests/bats/slack_open_test.bats`: 10/10 (new file)
- `shellcheck scripts/__slack_open.sh`: clean
- taskopen precedence checked end to end against a temp taskwarrior db with stub openers, so no test could reach the real Slack app or a browser
- `get_linear_issues` run against the real Linear API to confirm extraction on live data

The test helper fix is not incidental. It hardcoded the main checkout, so a suite run from a git worktree sourced `/home/decoder/dev/dotfiles/scripts/__github_issue_sync.sh` and passed without executing a line of the code under change.
